### PR TITLE
fix incoherent timestamp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5432,7 +5432,7 @@ checksum = "d2a965994514ab35d3893e9260245f2947fd1981cdd4fffd2c6e6d1a9ce02e6a"
 
 [[package]]
 name = "substratee-node"
-version = "0.6.4-sub2.0.0-alpha.7"
+version = "0.6.5-sub2.0.0-alpha.7"
 dependencies = [
  "futures 0.3.4",
  "log",
@@ -5460,7 +5460,7 @@ dependencies = [
 
 [[package]]
 name = "substratee-node-runtime"
-version = "0.6.4-sub2.0.0-alpha.7"
+version = "0.6.5-sub2.0.0-alpha.7"
 dependencies = [
  "frame-executive",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1535,7 +1535,7 @@ dependencies = [
 [[package]]
 name = "ias-verify"
 version = "0.1.0"
-source = "git+https://github.com/scs/pallet-substratee-registry.git?tag=v0.6.6-sub2.0.0-alpha.7#a09a8e89303843c264a91fa6ff73f7afcb9ac8c6"
+source = "git+https://github.com/scs/pallet-substratee-registry.git?tag=v0.6.7-sub2.0.0-alpha.7#c4bcb69975b96a52a68b95a852d3c4a02c84c241"
 dependencies = [
  "base64",
  "chrono",
@@ -2775,8 +2775,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-substratee-registry"
-version = "0.6.6-sub2.0.0-alpha.7"
-source = "git+https://github.com/scs/pallet-substratee-registry.git?tag=v0.6.6-sub2.0.0-alpha.7#a09a8e89303843c264a91fa6ff73f7afcb9ac8c6"
+version = "0.6.7-sub2.0.0-alpha.7"
+source = "git+https://github.com/scs/pallet-substratee-registry.git?tag=v0.6.7-sub2.0.0-alpha.7#c4bcb69975b96a52a68b95a852d3c4a02c84c241"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -7,7 +7,7 @@ homepage = 'https://www.scs.ch'
 license = 'Apache2'
 name = 'substratee-node'
 repository = 'https://github.com/scs/substratee-node/'
-version = '0.6.4-sub2.0.0-alpha.7'
+version = '0.6.5-sub2.0.0-alpha.7'
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']
@@ -19,7 +19,7 @@ structopt = '0.3.8'
 
 [dependencies.substratee-node-runtime]
 path = '../runtime'
-version = '0.6.4-sub2.0.0-alpha.7'
+version = '0.6.5-sub2.0.0-alpha.7'
 
 [dependencies.sc-basic-authorship]
 version = '0.8.0-alpha.7'

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -111,7 +111,7 @@ version = '2.0.0-alpha.7'
 default-features = false
 package = 'pallet-substratee-registry'
 git = "https://github.com/scs/pallet-substratee-registry.git"
-tag = "v0.6.6-sub2.0.0-alpha.7"
+tag = "v0.6.7-sub2.0.0-alpha.7"
 
 [dependencies.timestamp]
 default-features = false

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -5,7 +5,7 @@ homepage = 'https://www.scs.ch'
 license = 'Apache2'
 name = 'substratee-node-runtime'
 repository = 'https://github.com/scs/substratee-node/'
-version = '0.6.4-sub2.0.0-alpha.7'
+version = '0.6.5-sub2.0.0-alpha.7'
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']


### PR DESCRIPTION
the `pallet-substratee-registry` handled all timestamps as seconds while the `substratee-node` handled them as milliseconds. The registry update fixes this.

This lead to false  `Error::AttestationReportTooOld` errors.