### PR TITLE
add toolchain var to init script

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -4,9 +4,11 @@ set -e
 
 echo "*** Initializing WASM build environment"
 
+TOOLCHAIN=$(cat ./rust-toolchain)
+
 if [ -z $CI_PROJECT_NAME ] ; then
    rustup update nightly
    rustup update stable
 fi
 
-rustup target add wasm32-unknown-unknown --toolchain nightly
+rustup target add wasm32-unknown-unknown --toolchain $TOOLCHAIN


### PR DESCRIPTION
FIXED: in case of toolchain update, running init script did not update wasm toolchain to current version.