### PR TITLE
[runtime] remove deprecated type alias

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -172,7 +172,7 @@ parameter_types! {
 
 impl frame_system::Config for Runtime {
 	/// The basic call filter to use in dispatchable.
-	type BaseCallFilter = frame_support::traits::AllowAll;
+	type BaseCallFilter = frame_support::traits::Everything;
 	/// Block & extrinsics weights: base values and limits.
 	type BlockWeights = BlockWeights;
 	/// The maximum length of a block (in bytes).


### PR DESCRIPTION
Removes the compiler warning.