### PR TITLE
bump pallet-teerex to get new storage prefix.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2148,7 +2148,7 @@ dependencies = [
 [[package]]
 name = "ias-verify"
 version = "0.1.4"
-source = "git+https://github.com/integritee-network/pallet-teerex.git?branch=master#fab14a05744034c7a29fd6dc6f4437cb2272a7aa"
+source = "git+https://github.com/integritee-network/pallet-teerex.git?branch=master#2a2549ed5fc6ff147ec8138f653717c8e26f0cd8"
 dependencies = [
  "base64 0.11.0",
  "chrono",
@@ -3915,7 +3915,7 @@ dependencies = [
 [[package]]
 name = "pallet-teerex"
 version = "0.9.0"
-source = "git+https://github.com/integritee-network/pallet-teerex.git?branch=master#fab14a05744034c7a29fd6dc6f4437cb2272a7aa"
+source = "git+https://github.com/integritee-network/pallet-teerex.git?branch=master#2a2549ed5fc6ff147ec8138f653717c8e26f0cd8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",


### PR DESCRIPTION
While debugging the worker, I found that the api-client does not support discrepancies in the  `StoragePrefix` and the pallet's name.