### PR TITLE
[GA] add ubuntu 18.04 build for dev node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-20.04, ubuntu-18.04]
         rust: [stable]
         binary: [release]
     env:
@@ -142,7 +142,7 @@ jobs:
       - name: Upload integritee-node-dev
         uses: actions/upload-artifact@v2
         with:
-          name: integritee-node-dev-${{ github.sha }}
+          name: integritee-node-dev-${{ matrix.os }}-${{ github.sha }}
           path: target/release/integritee-node
           
       - name: Slack Notification


### PR DESCRIPTION
The ancient docker image in the worker cannot run a node binary built in 20.04 due to gcc incompatibilities.