### PR TITLE
Bump up version to 0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2280,7 +2280,7 @@ dependencies = [
 
 [[package]]
 name = "integritee-node"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "frame-benchmarking",
  "frame-benchmarking-cli",
@@ -2320,7 +2320,7 @@ dependencies = [
 
 [[package]]
 name = "integritee-node-runtime"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -7,7 +7,7 @@ homepage = 'https://integritee.network/'
 license = 'Apache2'
 name = 'integritee-node'
 repository = 'https://github.com/integritee-network/integritee-node'
-version = '0.9.0'
+version = '0.9.1'
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -5,7 +5,7 @@ homepage = 'https://integritee.network/'
 license = 'Apache2'
 name = 'integritee-node-runtime'
 repository = 'https://github.com/integritee-network/integritee-node'
-version = '0.9.0'
+version = '0.9.1'
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
To be able to use our new mainnet configs I need to release a new version 0.9.1
Related to integritee-network/deployment#15