### PR TITLE
Add dispatchable filtering for PoA mainnet launch

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -68,3 +68,6 @@ runtime-benchmarks = [
 ]
 # allow workers to register without remote attestation for dev purposes
 skip-ias-check = ["integritee-node-runtime/skip-ias-check"]
+
+#valid only for standalone mainnet
+mainnet-launch = ["integritee-node-runtime/mainnet-launch"]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -114,3 +114,4 @@ runtime-benchmarks = [
 	"pallet-treasury/runtime-benchmarks",
 	"pallet-vesting/runtime-benchmarks",
 ]
+mainnet-launch = []

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -216,17 +216,7 @@ parameter_types! {
 
 pub struct BaseFilter;
 impl Contains<Call> for BaseFilter {
-	//Filter shielding/unshielding calls in teerex, because of open security issues: see https://github.com/integritee-network/pallet-teerex/issues/7
-	#[cfg(not(feature = "mainnet-launch"))]
-	fn contains(call: &Call) -> bool {
-		!matches!(
-			call,
-			Call::Teerex(pallet_teerex::Call::shield_funds(..)) |
-				Call::Teerex(pallet_teerex::Call::unshield_funds(..))
-		)
-	}
 	//Block send extrinsics for mainnent before official token generation event
-	#[cfg(feature = "mainnet-launch")]
 	fn contains(call: &Call) -> bool {
 		!matches!(
 			call,
@@ -242,7 +232,10 @@ impl Contains<Call> for BaseFilter {
 // Configure FRAME pallets to include in runtime.
 
 impl frame_system::Config for Runtime {
-	/// The basic call filter to use in dispatchable.
+	#[cfg(not(feature = "mainnet-launch"))]
+	type BaseCallFilter = frame_support::traits::Everything;
+	//Block send extrinsics for mainnet before official token generation event
+	#[cfg(feature = "mainnet-launch")]
 	type BaseCallFilter = BaseFilter;
 	/// Block & extrinsics weights: base values and limits.
 	type BlockWeights = BlockWeights;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -40,6 +40,7 @@ use sp_std::prelude::*;
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 // A few exports that help ease life for downstream crates.
+use frame_support::traits::{Contains, Imbalance, InstanceFilter, OnUnbalanced};
 pub use frame_support::{
 	construct_runtime, parameter_types,
 	traits::{KeyOwnerProofSystem, Randomness, StorageInfo},
@@ -58,10 +59,6 @@ use pallet_transaction_payment::CurrencyAdapter;
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
 pub use sp_runtime::{Perbill, Permill};
-use frame_system::EnsureRoot;
-/// added by Integritee
-pub use pallet_teerex;
-use frame_support::traits::{OnUnbalanced, Imbalance, InstanceFilter, Contains};
 
 mod weights;
 
@@ -220,14 +217,8 @@ parameter_types! {
 //Don't allow any token actions
 pub struct BaseFilter;
 impl Contains<Call> for BaseFilter {
-	fn contains(call: &Call) -> bool
-	{
-		!matches!(
-			call,
-			Call::Balances(..) |
-			Call::Treasury(..) |
-			Call::Vesting(_)
-		)
+	fn contains(call: &Call) -> bool {
+		!matches!(call, Call::Balances(..) | Call::Treasury(..) | Call::Vesting(_))
 	}
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -40,7 +40,6 @@ use sp_std::prelude::*;
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 // A few exports that help ease life for downstream crates.
-use frame_support::traits::{Imbalance, InstanceFilter, OnUnbalanced};
 pub use frame_support::{
 	construct_runtime, parameter_types,
 	traits::{KeyOwnerProofSystem, Randomness, StorageInfo},
@@ -59,6 +58,10 @@ use pallet_transaction_payment::CurrencyAdapter;
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
 pub use sp_runtime::{Perbill, Permill};
+use frame_system::EnsureRoot;
+/// added by Integritee
+pub use pallet_teerex;
+use frame_support::traits::{OnUnbalanced, Imbalance, InstanceFilter, Contains};
 
 mod weights;
 
@@ -214,11 +217,25 @@ parameter_types! {
 	pub const SS58Prefix: u8 = 13;
 }
 
+//Don't allow any token actions
+pub struct BaseFilter;
+impl Contains<Call> for BaseFilter {
+	fn contains(call: &Call) -> bool
+	{
+		!matches!(
+			call,
+			Call::Balances(..) |
+			Call::Treasury(..)
+			//Call::Vesting(_)
+		)
+	}
+}
+
 // Configure FRAME pallets to include in runtime.
 
 impl frame_system::Config for Runtime {
 	/// The basic call filter to use in dispatchable.
-	type BaseCallFilter = frame_support::traits::Everything;
+	type BaseCallFilter = BaseFilter;
 	/// Block & extrinsics weights: base values and limits.
 	type BlockWeights = BlockWeights;
 	/// The maximum length of a block (in bytes).

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -225,8 +225,8 @@ impl Contains<Call> for BaseFilter {
 		!matches!(
 			call,
 			Call::Balances(..) |
-			Call::Treasury(..)
-			//Call::Vesting(_)
+			Call::Treasury(..) |
+			Call::Vesting(_)
 		)
 	}
 }
@@ -235,6 +235,9 @@ impl Contains<Call> for BaseFilter {
 
 impl frame_system::Config for Runtime {
 	/// The basic call filter to use in dispatchable.
+	#[cfg(not(feature = "mainnet-launch"))]
+	type BaseCallFilter = frame_support::traits::Everything;
+	#[cfg(feature = "mainnet-launch")]
 	type BaseCallFilter = BaseFilter;
 	/// Block & extrinsics weights: base values and limits.
 	type BlockWeights = BlockWeights;


### PR DESCRIPTION
Filter: vesting, balances and treasury call, when node compiled with  `--features mainnet-launch`
