### PR TITLE
[GA] downgrade build-skip-ias runner.os for worker compatible artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-18.04]
         rust: [stable]
         binary: [release]
     env:


### PR DESCRIPTION
Don't merge this. Just rebase onto master in case we need an updated artifact for the integritee-worker's CI.