### PR TITLE
enable token transfers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2282,7 +2282,7 @@ dependencies = [
 
 [[package]]
 name = "integritee-node"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "frame-benchmarking",
  "frame-benchmarking-cli",
@@ -2323,7 +2323,7 @@ dependencies = [
 
 [[package]]
 name = "integritee-node-runtime"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Every pallet with a `type WeightInfo` parameter in its config must be benchmarke
 For easy use of the binary without distributing a json chain spec, we generate a spec and build it into the binary
 ```
 ./target/release/integritee-node build-spec --chain integritee-solo-fresh --raw > integritee-solo.json
+./target/release/integritee-node build-spec --chain cranny-fresh --raw > cranny.json
 ```
-Then overwrite `./node/res/integritee-solo.json` but keep bootnode definitions and check other meta too.
+Then overwrite spec files in `./node/res/*.json` but keep bootnode definitions and check other meta too.
 
 Build the collator again and push.

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -8,7 +8,7 @@ license = 'Apache2'
 name = 'integritee-node'
 repository = 'https://github.com/integritee-network/integritee-node'
 #keep with runtime version
-version = '1.0.4'
+version = '1.0.5'
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -6,7 +6,7 @@ license = 'Apache2'
 name = 'integritee-node-runtime'
 repository = 'https://github.com/integritee-network/integritee-node'
 # keep patch revision with spec_version of runtime
-version = '1.0.4'
+version = '1.0.5'
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -125,7 +125,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	/// Version of the runtime specification. A full-node will not attempt to use its native
 	/// runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
 	/// `spec_version` and `authoring_version` are the same between Wasm and native.
-	spec_version: 4,
+	spec_version: 5,
 
 	/// Version of the implementation of the specification. Nodes are free to ignore this; it
 	/// serves only as an indication that the code is different; as long as the other two versions
@@ -225,16 +225,8 @@ impl Contains<Call> for BaseFilter {
 	fn contains(call: &Call) -> bool {
 		!matches!(
 			call,
-			Call::Balances(..) |
-			Call::Claims(..) |
-			Call::Multisig(_) |
-			Call::Proxy(_) |
-			Call::Teeracle(_) |
-			Call::Teerex(_) |
-			Call::Treasury(..) |
-			Call::Scheduler(_) |
-			Call::Utility(_) |
-			Call::Vesting(_)
+			// filter until we have resolved https://github.com/integritee-network/pallets/issues/17
+			Call::Teeracle(_) 
 		)
 	}
 }


### PR DESCRIPTION
* removed most extrinsic filters. 
* tested runtime upgrade from spec 4 to 5 locally. transfer is possible then
* minor README fixes