### PR TITLE
Standardize license name and authors

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-authors = ["Integritee AG"]
+authors = ["Integritee AG <hello@integritee.network>"]
 build = 'build.rs'
 description = 'Integritee Node for Solochain'
 edition = '2021'
 homepage = 'https://integritee.network/'
-license = 'Apache2'
+license = 'Apache-2.0'
 name = 'integritee-node'
 repository = 'https://github.com/integritee-network/integritee-node'
 #keep with runtime version

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-authors = ["Integritee AG"]
+authors = ["Integritee AG <hello@integritee.network>"]
 edition = '2021'
 homepage = 'https://integritee.network/'
-license = 'Apache2'
+license = 'Apache-2.0'
 name = 'integritee-node-runtime'
 repository = 'https://github.com/integritee-network/integritee-node'
 # keep patch revision with spec_version of runtime


### PR DESCRIPTION
cargo-about cannot deal with `Apache2` so adjust it follow the standard. I also modified the authors such that is the same as in our other repos. I did not check whether Apache-2.0 is actually appropriate. This is just to get the tooling working.