### PR TITLE
bump integritee pallets; reintroduce sending only every nth block to parentchain feature 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,7 +748,7 @@ dependencies = [
 [[package]]
 name = "claims-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=master#76cda7d2a13b0e90458c8053491060b306741498"
+source = "git+https://github.com/integritee-network/pallets.git?branch=master#2e55172af5249b1569617eaa080dfcd8fd9e54aa"
 dependencies = [
  "parity-scale-codec",
  "rustc-hex",
@@ -842,7 +842,7 @@ dependencies = [
 [[package]]
 name = "common-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=master#76cda7d2a13b0e90458c8053491060b306741498"
+source = "git+https://github.com/integritee-network/pallets.git?branch=master#2e55172af5249b1569617eaa080dfcd8fd9e54aa"
 dependencies = [
  "sp-std",
 ]
@@ -2411,7 +2411,7 @@ dependencies = [
 [[package]]
 name = "ias-verify"
 version = "0.1.4"
-source = "git+https://github.com/integritee-network/pallets.git?branch=master#76cda7d2a13b0e90458c8053491060b306741498"
+source = "git+https://github.com/integritee-network/pallets.git?branch=master#2e55172af5249b1569617eaa080dfcd8fd9e54aa"
 dependencies = [
  "base64",
  "chrono",
@@ -4152,7 +4152,7 @@ dependencies = [
 [[package]]
 name = "pallet-claims"
 version = "0.9.12"
-source = "git+https://github.com/integritee-network/pallets.git?branch=master#76cda7d2a13b0e90458c8053491060b306741498"
+source = "git+https://github.com/integritee-network/pallets.git?branch=master#2e55172af5249b1569617eaa080dfcd8fd9e54aa"
 dependencies = [
  "claims-primitives",
  "frame-benchmarking",
@@ -4276,7 +4276,7 @@ dependencies = [
 [[package]]
 name = "pallet-sidechain"
 version = "0.9.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=master#76cda7d2a13b0e90458c8053491060b306741498"
+source = "git+https://github.com/integritee-network/pallets.git?branch=master#2e55172af5249b1569617eaa080dfcd8fd9e54aa"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4315,7 +4315,7 @@ dependencies = [
 [[package]]
 name = "pallet-teeracle"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=master#76cda7d2a13b0e90458c8053491060b306741498"
+source = "git+https://github.com/integritee-network/pallets.git?branch=master#2e55172af5249b1569617eaa080dfcd8fd9e54aa"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4338,7 +4338,7 @@ dependencies = [
 [[package]]
 name = "pallet-teerex"
 version = "0.9.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=master#76cda7d2a13b0e90458c8053491060b306741498"
+source = "git+https://github.com/integritee-network/pallets.git?branch=master#2e55172af5249b1569617eaa080dfcd8fd9e54aa"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6629,7 +6629,7 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 [[package]]
 name = "sidechain-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=master#76cda7d2a13b0e90458c8053491060b306741498"
+source = "git+https://github.com/integritee-network/pallets.git?branch=master#2e55172af5249b1569617eaa080dfcd8fd9e54aa"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -7611,7 +7611,7 @@ checksum = "9410d0f6853b1d94f0e519fb95df60f29d2c1eff2d921ffdf01a4c8a3b54f12d"
 [[package]]
 name = "teeracle-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=master#76cda7d2a13b0e90458c8053491060b306741498"
+source = "git+https://github.com/integritee-network/pallets.git?branch=master#2e55172af5249b1569617eaa080dfcd8fd9e54aa"
 dependencies = [
  "common-primitives",
  "sp-std",
@@ -7621,7 +7621,7 @@ dependencies = [
 [[package]]
 name = "teerex-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=master#76cda7d2a13b0e90458c8053491060b306741498"
+source = "git+https://github.com/integritee-network/pallets.git?branch=master#2e55172af5249b1569617eaa080dfcd8fd9e54aa"
 dependencies = [
  "ias-verify",
  "parity-scale-codec",
@@ -7658,7 +7658,7 @@ dependencies = [
 [[package]]
 name = "test-utils"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=master#76cda7d2a13b0e90458c8053491060b306741498"
+source = "git+https://github.com/integritee-network/pallets.git?branch=master#2e55172af5249b1569617eaa080dfcd8fd9e54aa"
 dependencies = [
  "hex-literal",
  "log",

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -427,7 +427,6 @@ parameter_types! {
 impl pallet_sidechain::Config for Runtime {
 	type Event = Event;
 	type WeightInfo = weights::pallet_sidechain::WeightInfo<Runtime>;
-	type EarlyBlockProposalLenience = EarlyBlockProposalLenience;
 }
 
 parameter_types! {


### PR DESCRIPTION
The #144 has overwritten the new feature of only sending every nth block to the chain. This PR adds them again by including https://github.com/integritee-network/pallets/pull/114.

Creating a new docker image of the node after merging this PR and using it in https://github.com/integritee-network/worker/pull/1053 should fix the CI there.