### PR TITLE
GitHub Actions: bump versions to get rid of the deprecated warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,7 +257,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Cache target dir
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: "${{ github.workspace }}/runtime/target"
           key: srtool-target-${{ matrix.runtime }}-${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     name: Cancel Previous Runs
     runs-on: ubuntu-20.04
     steps:
-      - uses: styfle/cancel-workflow-action@0.4.1
+      - uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -62,7 +62,7 @@ jobs:
       RUST_BIN_DIR: target/${{ matrix.rust-target }}/debug
       RELEASE_NAME: debug
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Print env
         run: |
@@ -88,7 +88,7 @@ jobs:
 
       # Upload artifacts
       - name: Upload integritee-node
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: integritee-node-${{ github.sha }}
           path: target/release/integritee-node
@@ -117,7 +117,7 @@ jobs:
       RUST_BIN_DIR: target/${{ matrix.rust-target }}/debug
       RELEASE_NAME: debug
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Print env
         run: |
@@ -143,7 +143,7 @@ jobs:
 
       # Upload artifacts
       - name: Upload integritee-node-dev
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: integritee-node-dev-${{ github.sha }}
           path: target/release/integritee-node
@@ -172,7 +172,7 @@ jobs:
       RUST_BIN_DIR: target/${{ matrix.rust-target }}/debug
       RELEASE_NAME: debug
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Print env
         run: |
@@ -198,7 +198,7 @@ jobs:
 
       # Upload artifacts
       - name: Upload integritee-node-benchmarks
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: integritee-node-benchmarks-${{ github.sha }}
           path: target/release/integritee-node
@@ -220,7 +220,7 @@ jobs:
       RUSTV: ${{ matrix.rust }}
       TARGET: ${{ matrix.rust-target }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # With rustup's nice new toml format, we just need to run rustup show to install the toolchain
       # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659
@@ -254,7 +254,7 @@ jobs:
       matrix:
         runtime: ["integritee-node"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Cache target dir
         uses: actions/cache@v3
@@ -267,7 +267,7 @@ jobs:
 
       - name: Srtool build
         id: srtool_build
-        uses: chevdor/srtool-actions@v0.3.0
+        uses: chevdor/srtool-actions@v0.6.0
         with:
           chain: ${{ matrix.runtime }}
           runtime_dir: runtime
@@ -308,7 +308,7 @@ jobs:
 #          cat ${{ matrix.chain }}-diff.txt
 
       - name: Upload ${{ matrix.runtime }} srtool json
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.runtime }}-srtool-json-${{ github.sha }}
           path: |
@@ -320,7 +320,7 @@ jobs:
 
 
       - name: Upload ${{ matrix.runtime }} runtime
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.runtime }}-runtime-${{ github.sha }}
           path: |
@@ -348,9 +348,9 @@ jobs:
         config: [kusama]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      # - uses: actions/download-artifact@v2
+      # - uses: actions/download-artifact@v3
       #   with:
       #     name: integritee-node-${{ github.sha }}
 
@@ -370,7 +370,7 @@ jobs:
       #     sha256sum ${{ env.CHAIN_SPEC }}.json >> checksums.txt
 
       # - name: Upload ${{ env.CHAIN_SPEC }} Files
-      #   uses: actions/upload-artifact@v2
+      #   uses: actions/upload-artifact@v3
       #   with:
       #     name: ${{ env.CHAIN_SPEC }}-${{ github.sha }}
       #     path: |
@@ -396,16 +396,16 @@ jobs:
       release_url: ${{ steps.create-release.outputs.html_url }}
       asset_upload_url: ${{ steps.create-release.outputs.upload_url }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Download Integritee Collator
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: integritee-node-dev-${{ github.sha }}
           path: integritee-node-dev-tmp
 
       - name: Download Integritee Collator
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: integritee-node-${{ github.sha }}
 
@@ -453,8 +453,8 @@ jobs:
       matrix:
         runtime: ["integritee-node"]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
       - name: Set up Ruby 2.7
         uses: actions/setup-ruby@v1
         with:

--- a/.github/workflows/delete-release.yml
+++ b/.github/workflows/delete-release.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         binary: ["integritee-node", "integritee-node-dev"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set output
         id: vars

--- a/.github/workflows/publish-docker-release.yml
+++ b/.github/workflows/publish-docker-release.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         binary: ["integritee-node", "integritee-node-dev"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Download ${{ matrix.binary }} from release
         uses: dsaltares/fetch-gh-release-asset@master


### PR DESCRIPTION
GitHub Actions: bump cache version to get rid of the deprecated `save-state` command:
Deprecation warning in the CI: https://github.com/integritee-network/integritee-node/actions/runs/3468313454/jobs/5794005601#step:3:13

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

---
GitHub Actions: bump checkout version to get rid of the nodeJS 12 deprecation warnings:
```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2
```
NOTE: This PR should not trigger any deprecation warnings, please check it before merging.