### PR TITLE
Add chain properties to dev network chain specs and update readme about `skip-extrinsic-filtering`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A substrate-based node that maintains a registry of remote attested integritee-s
 Please see our [Integritee Book](https://book.integritee.network/howto_node.html) to learn how to build and run this.
 
 ### Note
-For there are some features that are highly relevant for developers:
+There are some cargo features that are highly relevant for developers:
 
 * `skip-ias-check`: allow registering enclaves without attestation report.
 * `skip-extrinsic-filtering`: We have a defensive filter for transfer extrinsics as we have an old solo-node running for archive purposes, which mustn't allow transfers. The filter can be deactivate with this feature.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Please see our [Integritee Book](https://book.integritee.network/howto_node.html
 There are some cargo features that are highly relevant for developers:
 
 * `skip-ias-check`: allow registering enclaves without attestation report.
-* `skip-extrinsic-filtering`: We have a defensive filter for transfer extrinsics as we have an old solo-node running for archive purposes, which mustn't allow transfers. The filter can be deactivate with this feature.
+* `skip-extrinsic-filtering`: We have a defensive filter for transfer extrinsics as we have an old solo-node running for archive purposes, which mustn't allow transfers. The filter can be deactivated with this feature.
+
 
 ## Benchmark the runtimes
 In `./scripts` we have a script for benchmarking the runtimes.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ A substrate-based node that maintains a registry of remote attested integritee-s
 ## Build and Run
 Please see our [Integritee Book](https://book.integritee.network/howto_node.html) to learn how to build and run this.
 
+### Note
+For there are some features that are highly relevant for developers:
+
+* `skip-ias-check`: allow registering enclaves without attestation report.
+* `skip-extrinsic-filtering`: We have a defensive filter for transfer extrinsics as we have an old solo-node running for archive purposes, which mustn't allow transfers. The filter can be deactivate with this feature.
+
 ## Benchmark the runtimes
 In `./scripts` we have a script for benchmarking the runtimes.
 

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -338,7 +338,7 @@ pub fn cranny_fresh_config() -> Result<ChainSpec, String> {
 		// chains have the same genesis hash.
 		None,
 		// Properties
-		Some(teer_properties()),
+		Some(cranny_properties()),
 		// Extensions
 		None,
 	))
@@ -392,6 +392,17 @@ fn teer_properties() -> sc_service::Properties {
 				"ss58Format": 13,
 				"tokenDecimals": 12,
 				"tokenSymbol": "TEER"
+			}"#,
+	)
+	.unwrap()
+}
+
+fn cranny_properties() -> sc_service::Properties {
+	serde_json::from_str(
+		r#"{
+			  	"ss58Format": 42,
+				"tokenDecimals": 12,
+				"tokenSymbol": "CRA"
 			}"#,
 	)
 	.unwrap()

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -89,13 +89,13 @@ pub fn development_config() -> Result<ChainSpec, String> {
 		// Telemetry
 		None,
 		// Protocol ID
-		None,
+		Some("teer"),
 		// Arbitrary string. Nodes will only synchronize with other nodes that have the same value
 		// in their `fork_id`. This can be used in order to segregate nodes in cases when multiple
 		// chains have the same genesis hash.
 		None,
 		// Properties
-		None,
+		Some(teer_properties()),
 		// Extensions
 		None,
 	))
@@ -144,11 +144,11 @@ pub fn local_testnet_config() -> Result<ChainSpec, String> {
 		// Telemetry
 		None,
 		// Protocol ID
-		None,
+		Some("teer"),
 		// Fork ID.
 		None,
 		// Properties
-		None,
+		Some(teer_properties()),
 		// Extensions
 		None,
 	))
@@ -262,16 +262,7 @@ pub fn integritee_solo_fresh_config() -> Result<ChainSpec, String> {
 		// chains have the same genesis hash.
 		None,
 		// Properties
-		Some(
-			serde_json::from_str(
-				r#"{
-				"ss58Format": 13,
-				"tokenDecimals": 12,
-				"tokenSymbol": "TEER"
-			}"#,
-			)
-			.unwrap(),
-		),
+		Some(teer_properties()),
 		// Extensions
 		None,
 	))
@@ -347,16 +338,7 @@ pub fn cranny_fresh_config() -> Result<ChainSpec, String> {
 		// chains have the same genesis hash.
 		None,
 		// Properties
-		Some(
-			serde_json::from_str(
-				r#"{
-				"ss58Format": 42,
-				"tokenDecimals": 12,
-				"tokenSymbol": "CRA"
-			}"#,
-			)
-			.unwrap(),
-		),
+		Some(teer_properties()),
 		// Extensions
 		None,
 	))
@@ -402,4 +384,15 @@ pub fn integritee_solo_config() -> Result<ChainSpec, String> {
 
 pub fn cranny_config() -> Result<ChainSpec, String> {
 	ChainSpec::from_json_bytes(&include_bytes!("../res/cranny.json")[..])
+}
+
+fn teer_properties() -> sc_service::Properties {
+	serde_json::from_str(
+		r#"{
+				"ss58Format": 13,
+				"tokenDecimals": 12,
+				"tokenSymbol": "TEER"
+			}"#,
+	)
+	.unwrap()
 }


### PR DESCRIPTION
* adding chain properties allows polkadot-js/apps to display the token metadata.
* also add documentation about the tricky feature flag, which prevents transfers