### PR TITLE
add exception for unidentified webpki license

### DIFF
--- a/about.toml
+++ b/about.toml
@@ -10,6 +10,9 @@ accepted = [
     "OpenSSL",
     "Unicode-DFS-2016",
     "GPL-3.0 WITH Classpath-exception-2.0",
+    # This is suddendly needed for webpki v0.22.0
+    # because it can't identify the licence. See #153.
+    "NOASSERTION"
 ]
 ignore-dev-dependencies = true
 ignore-build-dependencies = true


### PR DESCRIPTION
cargo-about has suddenly problems identifying the webpki v0.22.0 license, and then it falls back to the `NOASSERTION` license. This PR adds an exception for it.