### PR TITLE
[GA] add `--locked` to cargo builds and remove obsolete cargo clean

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,9 +82,7 @@ jobs:
 
       - name: Release
         if: ${{ matrix.binary == 'release' }}
-        run: |
-          cargo clean -p integritee-node
-          cargo build --release
+        run: cargo build --release --locked
 
       # Upload artifacts
       - name: Upload integritee-node
@@ -137,9 +135,7 @@ jobs:
 
       - name: Release
         if: ${{ matrix.binary == 'release' }}
-        run: |
-          cargo clean -p integritee-node
-          cargo build --release --features skip-ias-check,skip-extrinsic-filtering
+        run: cargo build --release --locked --features skip-ias-check,skip-extrinsic-filtering
 
       # Upload artifacts
       - name: Upload integritee-node-dev
@@ -192,9 +188,7 @@ jobs:
 
       - name: Build benchmarking binary
         if: ${{ matrix.binary == 'release' }}
-        run: |
-          cargo clean -p integritee-node
-          cargo build --release --features runtime-benchmarks
+        run: cargo build --release --locked --features runtime-benchmarks
 
       # Upload artifacts
       - name: Upload integritee-node-benchmarks


### PR DESCRIPTION
* `cargo clean -p integritee-node` only existed due to an incremental build error with an old rust-toolchain.
* `--locked` enforces and up-to-date Cargo.lock and makes the CI fail otherwise.