### PR TITLE
bump version: v1.0.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2534,7 +2534,7 @@ dependencies = [
 
 [[package]]
 name = "integritee-node"
-version = "1.0.9"
+version = "1.0.26"
 dependencies = [
  "clap",
  "frame-benchmarking",
@@ -2578,7 +2578,7 @@ dependencies = [
 
 [[package]]
 name = "integritee-node-runtime"
-version = "1.0.9"
+version = "1.0.26"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",

--- a/README.md
+++ b/README.md
@@ -13,6 +13,20 @@ There are some cargo features that are highly relevant for developers:
 * `skip-ias-check`: allow registering enclaves without attestation report.
 * `skip-extrinsic-filtering`: We have a defensive filter for transfer extrinsics as we have an old solo-node running for archive purposes, which mustn't allow transfers. The filter can be deactivated with this feature.
 
+## Versioning
+There are two important version parameters in the runtime that change behaviour.
+* `spec_version` always needs to be updated when the runtime logic changes.
+* `transaction_version` always needs to updated when:
+  * extrinsics are removed
+  * extrinsics are changed
+  * extrinsics are added somewhere in between
+Extrinsics being added to the end are fine as they don't interfere with the existing call enum that the runtime macro
+generates.
+
+Convention:
+1. The runtime's and node's crate patch version must be aligned with the `spec_version`.
+2. The crate version must be the same as the tag that is created for the release.
+
 
 ## Benchmark the runtimes
 In `./scripts` we have a script for benchmarking the runtimes.

--- a/README.md
+++ b/README.md
@@ -14,14 +14,9 @@ There are some cargo features that are highly relevant for developers:
 * `skip-extrinsic-filtering`: We have a defensive filter for transfer extrinsics as we have an old solo-node running for archive purposes, which mustn't allow transfers. The filter can be deactivated with this feature.
 
 ## Versioning
-There are two important version parameters in the runtime that change behaviour.
+There are two important version parameters in the `RuntimeVersion` that change behaviour, see [RustDocs](https://paritytech.github.io/substrate/master/sp_version/struct.RuntimeVersion.html).
 * `spec_version` always needs to be updated when the runtime logic changes.
-* `transaction_version` always needs to updated when:
-  * extrinsics are removed
-  * extrinsics are changed
-  * extrinsics are added somewhere in between
-Extrinsics being added to the end are fine as they don't interfere with the existing call enum that the runtime macro
-generates.
+* `transaction_version`, see desctription in [RustDocs](https://paritytech.github.io/substrate/master/sp_version/struct.RuntimeVersion.html).
 
 Convention:
 1. The runtime's and node's crate patch version must be aligned with the `spec_version`.

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -8,7 +8,7 @@ license = 'Apache-2.0'
 name = 'integritee-node'
 repository = 'https://github.com/integritee-network/integritee-node'
 #keep with runtime version
-version = '1.0.9'
+version = '1.0.26'
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -6,7 +6,7 @@ license = 'Apache-2.0'
 name = 'integritee-node-runtime'
 repository = 'https://github.com/integritee-network/integritee-node'
 # keep patch revision with spec_version of runtime
-version = '1.0.9'
+version = '1.0.26'
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -132,7 +132,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	/// Version of the runtime specification. A full-node will not attempt to use its native
 	/// runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
 	/// `spec_version` and `authoring_version` are the same between Wasm and native.
-	spec_version: 25,
+	spec_version: 26,
 
 	/// Version of the implementation of the specification. Nodes are free to ignore this; it
 	/// serves only as an indication that the code is different; as long as the other two versions
@@ -153,7 +153,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	/// index.
 	///
 	/// It need *not* change when a new module is added or when a dispatchable is added.
-	transaction_version: 4,
+	transaction_version: 5,
 	state_version: 0,
 };
 


### PR DESCRIPTION
The versioning was messed up, so I added a readme section with more details on how to do it. Please comment, when something is not clear.

Note: because of this inconsistency, I will bump the release directly to v1.0.26 afterwards)