### PR TITLE
[CI] fix runtime release by removing the no-longer supported ruby action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -471,10 +471,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3
-      - name: Set up Ruby 2.7
-        uses: actions/setup-ruby@v1
-        with:
-          ruby-version: 2.7
+
+      - name: Set up Ruby 3
+        uses: ruby/setup-ruby@v1
+          with:
+            ruby-version: '3.0'
 
       - name: Get runtime version
         id: get-runtime-ver

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -474,8 +474,8 @@ jobs:
 
       - name: Set up Ruby 3
         uses: ruby/setup-ruby@v1
-          with:
-            ruby-version: '3.0'
+        with:
+          ruby-version: '3.0'
 
       - name: Get runtime version
         id: get-runtime-ver


### PR DESCRIPTION
I already did the same fix for encointer, so I know it works: https://github.com/encointer/encointer-node/pull/270