### PR TITLE
Fix runtime builds by specifying srtool image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,9 +361,10 @@ jobs:
 
       - name: Srtool build
         id: srtool_build
-        uses: chevdor/srtool-actions@v0.6.0
+        uses: chevdor/srtool-actions@v0.7.0
         with:
           chain: ${{ matrix.runtime }}
+          tag: 1.66.1
           runtime_dir: runtime
 
       - name: Summary


### PR DESCRIPTION
The srtool action does automatically build in the latest srtool docker image, which does no longer contain the nightly.

We can remove this patch when we can build with rust stable, but this needs a substrate update if I am not mistaken. For more info see https://github.com/paritytech/srtool/issues/62