### PR TITLE
v1.0.36; bump runtime and client version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2926,7 +2926,7 @@ dependencies = [
 
 [[package]]
 name = "integritee-node"
-version = "1.0.34"
+version = "1.0.36"
 dependencies = [
  "clap",
  "frame-benchmarking",
@@ -2971,7 +2971,7 @@ dependencies = [
 
 [[package]]
 name = "integritee-node-runtime"
-version = "1.0.32"
+version = "1.0.33"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -8,7 +8,7 @@ license = 'Apache-2.0'
 name = 'integritee-node'
 repository = 'https://github.com/integritee-network/integritee-node'
 # Align major.minor revision with the runtimes, bump patch revision ad lib. Make this the github release tag.
-version = '1.0.34'
+version = '1.0.36'
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -6,7 +6,7 @@ license = 'Apache-2.0'
 name = 'integritee-node-runtime'
 repository = 'https://github.com/integritee-network/integritee-node'
 # keep patch revision with spec_version of runtime
-version = '1.0.32'
+version = '1.0.33'
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -138,7 +138,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	/// Version of the runtime specification. A full-node will not attempt to use its native
 	/// runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
 	/// `spec_version` and `authoring_version` are the same between Wasm and native.
-	spec_version: 32,
+	spec_version: 33,
 
 	/// Version of the implementation of the specification. Nodes are free to ignore this; it
 	/// serves only as an indication that the code is different; as long as the other two versions


### PR DESCRIPTION
Bumped the client version from v1.0.34 → v1.0.36 because there was a misalignment between the tag and the version somehow.