### PR TITLE
[GHA] fix getting runtime version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -504,7 +504,8 @@ jobs:
           ls
           ls "${{ matrix.runtime }}-runtime-${{ github.sha }}"
           runtime_ver="$(ruby -e 'require "./scripts/github/lib.rb"; puts get_runtime()')"
-          echo "{runtime_ver}={$runtime_ver}" >> $GITHUB_OUTPUT
+          echo "Found version: >$runtime_ver<"
+          echo "runtime_ver={$runtime_ver}" >> $GITHUB_OUTPUT
 
       - name: Upload compact ${{ matrix.runtime }} wasm
         uses: actions/upload-release-asset@v1


### PR DESCRIPTION
* Closes #182

We had to fix the same error in the parachain at some point: https://github.com/integritee-network/parachain/pull/189