### PR TITLE
Default to no extrinsic filtering and remove dev binary as it is obsolete now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,7 +316,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   create_artifacts:
-    needs: [ build_live_binaries, build-runtimes ]
+    needs: [ build_binaries, build-runtimes ]
     runs-on: ubuntu-20.04
     env:
       CHAIN_SPEC: ${{ matrix.chain }}-${{ matrix.config }}
@@ -370,7 +370,7 @@ jobs:
     name: Draft Release
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
-    needs: [create_artifacts, build_live_binaries, check]
+    needs: [create_artifacts, build_binaries, check]
     outputs:
       release_url: ${{ steps.create-release.outputs.html_url }}
       asset_upload_url: ${{ steps.create-release.outputs.upload_url }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,26 +370,17 @@ jobs:
     name: Draft Release
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
-    needs: [create_artifacts, build_live_binaries, build_dev_binaries, check]
+    needs: [create_artifacts, build_live_binaries, check]
     outputs:
       release_url: ${{ steps.create-release.outputs.html_url }}
       asset_upload_url: ${{ steps.create-release.outputs.upload_url }}
     steps:
       - uses: actions/checkout@v3
 
-      - name: Download Integritee Collator
-        uses: actions/download-artifact@v3
-        with:
-          name: integritee-node-dev-${{ github.sha }}
-          path: integritee-node-dev-tmp
-
-      - name: Download Integritee Collator
+      - name: Download Integritee Node
         uses: actions/download-artifact@v3
         with:
           name: integritee-node-${{ github.sha }}
-
-      - name: Move binaries
-        run: mv integritee-node-dev-tmp/integritee-node ./integritee-node-dev
 
       - name: Create required package.json
         run: test -f package.json || echo '{}' >package.json
@@ -413,7 +404,6 @@ jobs:
           draft: true
           files: |
             integritee-node
-            integritee-node-dev
 
       - name: Slack Notification
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           access_token: ${{ secrets.GITHUB_TOKEN }}
 
-  build_live_binaries:
+  build_binaries:
     name: Live build ${{ matrix.binary }} for ${{ matrix.rust-target }} on (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
@@ -94,64 +94,6 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: integritee-node-${{ github.sha }}
-          path: target/release/integritee-node
-
-      - name: Slack Notification
-        uses: 8398a7/action-slack@v3
-        if: failure()
-        with:
-          status: ${{ job.status }}
-          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took # selectable (default: repo,message)
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-  build_dev_binaries:
-    name: Development build ${{ matrix.binary }} for ${{ matrix.rust-target }} on (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-20.04]
-        rust: [stable]
-        binary: [release]
-    env:
-      RUST_BACKTRACE: full
-      RUSTV: ${{ matrix.rust }}
-      TARGET: ${{ matrix.rust-target }}
-      RUST_BIN_DIR: target/${{ matrix.rust-target }}/debug
-      RELEASE_NAME: debug
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Print env
-        run: |
-          echo "RUST_BIN_DIR = ${{ env.RUST_BIN_DIR }} "
-
-      # With rustup's nice new toml format, we just need to run rustup show to install the toolchain
-      # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659
-      - name: Setup Rust toolchain
-        run: rustup show
-
-      - name: Install dependencies
-        run: |
-          sudo apt update && \
-          sudo apt install --assume-yes protobuf-compiler
-
-      - name: Install llvm-10
-        run: sudo apt-get install llvm-10 clang-10
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: ${{ matrix.os }}-${{ env.RUST_BIN_DIR }}-${{ matrix.binary }}
-
-      - name: Release
-        if: ${{ matrix.binary == 'release' }}
-        run: cargo build --release --locked
-
-      # Upload artifacts
-      - name: Upload integritee-node-dev
-        uses: actions/upload-artifact@v3
-        with:
-          name: integritee-node-dev-${{ github.sha }}
           path: target/release/integritee-node
 
       - name: Slack Notification

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
 
       - name: Release
         if: ${{ matrix.binary == 'release' }}
-        run: cargo build --release --locked --features skip-extrinsic-filtering
+        run: cargo build --release --locked
 
       # Upload artifacts
       - name: Upload integritee-node-dev

--- a/.github/workflows/delete-release.yml
+++ b/.github/workflows/delete-release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        binary: ["integritee-node", "integritee-node-dev" ]
+        binary: ["integritee-node"]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/publish-docker-release.yml
+++ b/.github/workflows/publish-docker-release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        binary: ["integritee-node", "integritee-node-dev"]
+        binary: ["integritee-node"]
     steps:
       - uses: actions/checkout@v3
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,8 @@ A substrate-based node that maintains a registry of remote attested integritee-s
 1. See the substrate install docs to install the preliminaries: [https://docs.substrate.io/install](https://docs.substrate.io/install).
 2. Build the node:
      ```
-     cargo build --release --features "skip-extrinsic-filtering" 
+     cargo build --release 
      ```
-
-### Note
-There are some cargo features that are highly relevant for developers:
-
-* `skip-extrinsic-filtering`: We have a defensive filter for transfer extrinsics as we have an old solo-node running for archive purposes, which mustn't allow transfers. The filter can be deactivated with this feature.
 
 ## Versioning
 There are two important version parameters in the `RuntimeVersion` that change behaviour, see [RustDocs](https://paritytech.github.io/substrate/master/sp_version/struct.RuntimeVersion.html).

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -66,7 +66,7 @@ integritee-node-runtime = { path = '../runtime' }
 substrate-build-script-utils = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 
 [features]
-default = []
+default = ["skip-extrinsic-filtering"]
 runtime-benchmarks = [
     "integritee-node-runtime/runtime-benchmarks",
     "sc-service/runtime-benchmarks",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -66,10 +66,10 @@ integritee-node-runtime = { path = '../runtime' }
 substrate-build-script-utils = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 
 [features]
-default = ["skip-extrinsic-filtering"]
+default = []
 runtime-benchmarks = [
     "integritee-node-runtime/runtime-benchmarks",
     "sc-service/runtime-benchmarks",
 ]
-# lift filters for development binaries
-skip-extrinsic-filtering = ["integritee-node-runtime/skip-extrinsic-filtering"]
+# for secure launch of a live solo network, do enable extrinsic filtering
+extrinsic-filtering = ["integritee-node-runtime/extrinsic-filtering"]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -68,7 +68,7 @@ substrate-wasm-builder = { git = "https://github.com/paritytech/substrate.git", 
 
 [features]
 default = ["std"]
-skip-extrinsic-filtering = []
+extrinsic-filtering = []
 std = [
     "codec/std",
     "scale-info/std",

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -264,9 +264,9 @@ impl Contains<RuntimeCall> for BaseFilter {
 // Configure FRAME pallets to include in runtime.
 
 impl frame_system::Config for Runtime {
-	#[cfg(feature = "skip-extrinsic-filtering")]
+	#[cfg(not(feature = "extrinsic-filtering"))]
 	type BaseCallFilter = frame_support::traits::Everything;
-	#[cfg(not(feature = "skip-extrinsic-filtering"))]
+	#[cfg(feature = "extrinsic-filtering")]
 	type BaseCallFilter = BaseFilter;
 	/// Block & extrinsics weights: base values and limits.
 	type BlockWeights = BlockWeights;


### PR DESCRIPTION
removes the annoying default to filtering all extrinsics for non-sudoers

the only consideration here is that the filter has to be opted in for launching a new production solonet. Which is not expected to ever happen again

* Closes #181 