### PR TITLE
SBliFF backport for CI of worker sdk >=0.12.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -920,7 +920,7 @@ dependencies = [
 [[package]]
 name = "claims-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.9-polkadot-v0.9.42#8469a054e131f87f67f2829331b88ecce30a432d"
+source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.12-polkadot-v0.9.42#c7b1400d4a55f5588737ea1a4cb99145da3e5c79"
 dependencies = [
  "parity-scale-codec",
  "rustc-hex",
@@ -1013,7 +1013,7 @@ dependencies = [
 [[package]]
 name = "common-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.9-polkadot-v0.9.42#8469a054e131f87f67f2829331b88ecce30a432d"
+source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.12-polkadot-v0.9.42#c7b1400d4a55f5588737ea1a4cb99145da3e5c79"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -1853,7 +1853,7 @@ dependencies = [
 [[package]]
 name = "enclave-bridge-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.9-polkadot-v0.9.42#8469a054e131f87f67f2829331b88ecce30a432d"
+source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.12-polkadot-v0.9.42#c7b1400d4a55f5588737ea1a4cb99145da3e5c79"
 dependencies = [
  "common-primitives",
  "log",
@@ -3039,7 +3039,7 @@ dependencies = [
 
 [[package]]
 name = "integritee-node"
-version = "1.1.5"
+version = "1.1.6"
 dependencies = [
  "clap",
  "frame-benchmarking",
@@ -3084,7 +3084,7 @@ dependencies = [
 
 [[package]]
 name = "integritee-node-runtime"
-version = "1.1.37"
+version = "1.1.38"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
@@ -4685,7 +4685,7 @@ dependencies = [
 [[package]]
 name = "pallet-claims"
 version = "0.9.12"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.9-polkadot-v0.9.42#8469a054e131f87f67f2829331b88ecce30a432d"
+source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.12-polkadot-v0.9.42#c7b1400d4a55f5588737ea1a4cb99145da3e5c79"
 dependencies = [
  "claims-primitives",
  "frame-benchmarking",
@@ -4705,7 +4705,7 @@ dependencies = [
 [[package]]
 name = "pallet-enclave-bridge"
 version = "0.12.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.9-polkadot-v0.9.42#8469a054e131f87f67f2829331b88ecce30a432d"
+source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.12-polkadot-v0.9.42#c7b1400d4a55f5588737ea1a4cb99145da3e5c79"
 dependencies = [
  "enclave-bridge-primitives",
  "frame-benchmarking",
@@ -4852,7 +4852,7 @@ dependencies = [
 [[package]]
 name = "pallet-sidechain"
 version = "0.11.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.9-polkadot-v0.9.42#8469a054e131f87f67f2829331b88ecce30a432d"
+source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.12-polkadot-v0.9.42#c7b1400d4a55f5588737ea1a4cb99145da3e5c79"
 dependencies = [
  "enclave-bridge-primitives",
  "frame-benchmarking",
@@ -4893,7 +4893,7 @@ dependencies = [
 [[package]]
 name = "pallet-teeracle"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.9-polkadot-v0.9.42#8469a054e131f87f67f2829331b88ecce30a432d"
+source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.12-polkadot-v0.9.42#c7b1400d4a55f5588737ea1a4cb99145da3e5c79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4917,7 +4917,7 @@ dependencies = [
 [[package]]
 name = "pallet-teerex"
 version = "0.10.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.9-polkadot-v0.9.42#8469a054e131f87f67f2829331b88ecce30a432d"
+source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.12-polkadot-v0.9.42#c7b1400d4a55f5588737ea1a4cb99145da3e5c79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7502,7 +7502,7 @@ dependencies = [
 [[package]]
 name = "sgx-verify"
 version = "0.1.4"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.9-polkadot-v0.9.42#8469a054e131f87f67f2829331b88ecce30a432d"
+source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.12-polkadot-v0.9.42#c7b1400d4a55f5588737ea1a4cb99145da3e5c79"
 dependencies = [
  "base64 0.13.1",
  "chrono",
@@ -7612,7 +7612,7 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 [[package]]
 name = "sidechain-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.9-polkadot-v0.9.42#8469a054e131f87f67f2829331b88ecce30a432d"
+source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.12-polkadot-v0.9.42#c7b1400d4a55f5588737ea1a4cb99145da3e5c79"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8663,7 +8663,7 @@ checksum = "1d2faeef5759ab89935255b1a4cd98e0baf99d1085e37d36599c625dac49ae8e"
 [[package]]
 name = "teeracle-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.9-polkadot-v0.9.42#8469a054e131f87f67f2829331b88ecce30a432d"
+source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.12-polkadot-v0.9.42#c7b1400d4a55f5588737ea1a4cb99145da3e5c79"
 dependencies = [
  "common-primitives",
  "sp-std",
@@ -8673,7 +8673,7 @@ dependencies = [
 [[package]]
 name = "teerex-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.9-polkadot-v0.9.42#8469a054e131f87f67f2829331b88ecce30a432d"
+source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.12-polkadot-v0.9.42#c7b1400d4a55f5588737ea1a4cb99145da3e5c79"
 dependencies = [
  "common-primitives",
  "derive_more",
@@ -8717,7 +8717,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 [[package]]
 name = "test-utils"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.9-polkadot-v0.9.42#8469a054e131f87f67f2829331b88ecce30a432d"
+source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.12-polkadot-v0.9.42#c7b1400d4a55f5588737ea1a4cb99145da3e5c79"
 dependencies = [
  "log",
  "sgx-verify",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -8,7 +8,7 @@ license = 'Apache-2.0'
 name = 'integritee-node'
 repository = 'https://github.com/integritee-network/integritee-node'
 # Align major.minor revision with the runtimes, bump patch revision ad lib. Make this the github release tag.
-version = '1.1.5'
+version = '1.1.6'
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -6,7 +6,7 @@ license = 'Apache-2.0'
 name = 'integritee-node-runtime'
 repository = 'https://github.com/integritee-network/integritee-node'
 # keep patch revision with spec_version of runtime
-version = '1.1.37'
+version = '1.1.38'
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -30,11 +30,11 @@ pallet-treasury = { default-features = false, git = "https://github.com/parityte
 pallet-utility = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 pallet-vesting = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 
-pallet-claims = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.9-polkadot-v0.9.42" }
-pallet-enclave-bridge = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.9-polkadot-v0.9.42" }
-pallet-sidechain = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.9-polkadot-v0.9.42" }
-pallet-teeracle = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.9-polkadot-v0.9.42" }
-pallet-teerex = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.9-polkadot-v0.9.42" }
+pallet-claims = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.12-polkadot-v0.9.42" }
+pallet-enclave-bridge = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.12-polkadot-v0.9.42" }
+pallet-sidechain = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.12-polkadot-v0.9.42" }
+pallet-teeracle = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.12-polkadot-v0.9.42" }
+pallet-teerex = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.12-polkadot-v0.9.42" }
 
 sp-api = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-block-builder = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -141,7 +141,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	/// Version of the runtime specification. A full-node will not attempt to use its native
 	/// runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
 	/// `spec_version` and `authoring_version` are the same between Wasm and native.
-	spec_version: 37,
+	spec_version: 38,
 
 	/// Version of the implementation of the specification. Nodes are free to ignore this; it
 	/// serves only as an indication that the code is different; as long as the other two versions
@@ -162,7 +162,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	/// index.
 	///
 	/// It need *not* change when a new module is added or when a dispatchable is added.
-	transaction_version: 6,
+	transaction_version: 7,
 	state_version: 0,
 };
 


### PR DESCRIPTION
In order to fix CI in the worker, we need to backport [SBliFF](https://github.com/integritee-network/pallets/pull/255).
