### PR TITLE
[CI] bump artifact actions to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
 
       # Upload artifacts
       - name: Upload integritee-node
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: integritee-node-${{ github.sha }}
           path: target/release/integritee-node
@@ -149,7 +149,7 @@ jobs:
 
       # Upload artifacts
       - name: Upload integritee-node-benchmarks
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: integritee-node-benchmarks-${{ github.sha }}
           path: target/release/integritee-node
@@ -222,7 +222,7 @@ jobs:
         run: cargo +stable about generate about.hbs > license.html
 
       - name: Archive license file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: license
           path: license.html
@@ -302,7 +302,7 @@ jobs:
       #          cat ${{ matrix.chain }}-diff.txt
 
       - name: Upload ${{ matrix.runtime }} srtool json
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.runtime }}-srtool-json-${{ github.sha }}
           path: |
@@ -314,7 +314,7 @@ jobs:
 
 
       - name: Upload ${{ matrix.runtime }} runtime
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.runtime }}-runtime-${{ github.sha }}
           path: |
@@ -344,7 +344,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      # - uses: actions/download-artifact@v3
+      # - uses: actions/download-artifact@v4
       #   with:
       #     name: integritee-node-${{ github.sha }}
 
@@ -364,7 +364,7 @@ jobs:
       #     sha256sum ${{ env.CHAIN_SPEC }}.json >> checksums.txt
 
       # - name: Upload ${{ env.CHAIN_SPEC }} Files
-      #   uses: actions/upload-artifact@v3
+      #   uses: actions/upload-artifact@v4
       #   with:
       #     name: ${{ env.CHAIN_SPEC }}-${{ github.sha }}
       #     path: |
@@ -393,7 +393,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Download Integritee Node
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: integritee-node-${{ github.sha }}
 
@@ -438,7 +438,7 @@ jobs:
         runtime: [ "integritee-node" ]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
 
       - name: Set up Ruby 3
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
They are deprecated and will be removed on the 30.01.2025